### PR TITLE
feat: Add CLI arguments support for LaunchAndKill action

### DIFF
--- a/src/TimeToKill.App/Services/TimerActionService.cs
+++ b/src/TimeToKill.App/Services/TimerActionService.cs
@@ -49,15 +49,15 @@ public class TimerActionService
 	}
 
 	// Launch a process, skipping if already running. Used by TimerManager on start for LaunchAndKill presets.
-	public ActionResult Launch(string processPath)
+	public ActionResult Launch(string processPath, string arguments = null)
 	{
 		var exeName = ProcessNameHelper.GetExeName(processPath);
 		if (ProcessTools.IsProcessRunning(exeName)) {
 			return ActionResult.Succeeded(exeName, TimerActionType.LaunchAndKill, 0, "Process already running, skipping launch");
 		}
 
-		var (success, error) = ProcessTools.LaunchProcess(processPath);
-		
+		var (success, error) = ProcessTools.LaunchProcess(processPath, arguments);
+
 		if (success)
 			return ActionResult.Succeeded(exeName, TimerActionType.LaunchAndKill, 1, "Launched process");
 		else

--- a/src/TimeToKill.App/Services/TimerManager.cs
+++ b/src/TimeToKill.App/Services/TimerManager.cs
@@ -96,7 +96,7 @@ public class TimerManager
 
 		// Launch process outside the lock for LaunchAndKill
 		if (preset.ActionType == TimerActionType.LaunchAndKill) {
-			_actionService.Launch(preset.ProcessName);
+			_actionService.Launch(preset.ProcessName, preset.ActionArgs);
 		}
 
 		return timer;

--- a/src/TimeToKill.Shared/Tools/ProcessTools.cs
+++ b/src/TimeToKill.Shared/Tools/ProcessTools.cs
@@ -149,8 +149,8 @@ public static class ProcessTools
 			: (false, 0, "Failed to demote priority of any processes");
 	}
 	
-	// Launch a process by path.
-	public static (bool Success, string Error) LaunchProcess(string processPath)
+	// Launch a process by path with optional CLI arguments.
+	public static (bool Success, string Error) LaunchProcess(string processPath, string arguments = null)
 	{
 		if (string.IsNullOrWhiteSpace(processPath)) {
 			return (false, "Process path cannot be empty");
@@ -161,6 +161,11 @@ public static class ProcessTools
 				FileName = processPath,
 				UseShellExecute = true
 			};
+
+			if (!string.IsNullOrWhiteSpace(arguments)) {
+				startInfo.Arguments = arguments;
+			}
+
 			var proc = Process.Start(startInfo);
 			return proc != null
 				? (true, (string)null)


### PR DESCRIPTION
Add support for CLI arguments when launching processes via the LaunchAndKill action.

## Changes
- Add optional arguments parameter to ProcessTools.LaunchProcess
- Pass ActionArgs through TimerActionService.Launch
- Wire up ActionArgs in TimerManager.Start for LaunchAndKill presets

This allows users to specify CLI arguments when launching processes.
Example: `/path/to/app.exe` with args `--arg1 xyz --arg2 abc`

Fixes #3
